### PR TITLE
Fix broken reference link

### DIFF
--- a/README.md
+++ b/README.md
@@ -688,6 +688,6 @@ While on testnet, the core team will arbitrate conflicts and we expect to formal
 - Does the user have a reasonable claim to the name? (e.g. their name also Elon?)
 - Does the user hold similar, active handles on other networks? (e.g. they own elon on twitter and elon.ens)
 
-[^delta-state]: van der Linde, A., Leitão, J., & Preguiça, N. (2016). Δ-CRDTs: Making δ-CRDTs delta-based. Proceedings of the 2nd Workshop on the Principles and Practice of Consistency for Distributed Data. https://doi.org/10.1145/2911151.2911163p
+[^delta-state]: van der Linde, A., Leitão, J., & Preguiça, N. (2016). Δ-CRDTs: Making δ-CRDTs delta-based. Proceedings of the 2nd Workshop on the Principles and Practice of Consistency for Distributed Data. https://doi.org/10.1145/2911151.2911163
 [^two-phase-set]: Shapiro, Marc; Preguiça, Nuno; Baquero, Carlos; Zawirski, Marek (2011). "A Comprehensive Study of Convergent and Commutative Replicated Data Types". Rr-7506.
 [^ed25519]: Bernstein, D.J., Duif, N., Lange, T. et al. High-speed high-security signatures. J Cryptogr Eng 2, 77–89 (2012). https://doi.org/10.1007/s13389-012-0027-1


### PR DESCRIPTION
The "Δ-CRDTs: Making δ-CRDTs delta-based" reference link is broken because of a minor typo. This PR fixes it.