### PR TITLE
fixed broken link for FIP Discussions

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The specification is maintained as a Markdown file. There are three important se
 
 1. [Overview](/hub/README.md) - A high level overview of the protocol.
 2. [Specification](/hub/README.md) - The technical spec for implementing Farcaster.
-3. [FIP Discussions](https://github.com/farcasterxyz/protocol/discussionsd) - A forum where new proposals to change the specification are discussed.
+3. [FIP Discussions](https://github.com/farcasterxyz/protocol/discussions) - A forum where new proposals to change the specification are discussed.
 
 ## Contributing
 


### PR DESCRIPTION
Currently: https://github.com/farcasterxyz/protocol/discussionsd

Should be: https://github.com/farcasterxyz/protocol/discussions