### PR TITLE
fix: adds EIP1271 to supported signature type

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -195,7 +195,7 @@ A user authorizes an application's Signer with a signature from their custody ad
 ```mermaid
 graph TD
     Custody2([Custody Address]) --> SignerA1([Signer A])
-    Custody2 -->  |ECDSA Signature|SignerC([Signer B])
+    Custody2 -->  |ECDSA / EIP1271 Signature|SignerC([Signer B])
     SignerC -->  CastA[Cast]
     SignerC -->  |EdDSA Signature| CastB[Cast]
     SignerA1 -->  CastC[Cast]


### PR DESCRIPTION
Adds EIP1271 signature type to signer registry graph