### PR TITLE
Removed Scam Telegram Link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,12 +4,12 @@ Farcaster is a community-driven protocol and we welcome contributors of all skil
 
 ## Ramping Up
 
-If you're new to Farcaster we recommend joining the telegram channels and watching the most recent developer call to get up to speed on what the community is focussed on.
+If you're new to Farcaster we recommend joining the Telegram channels and watching the most recent developer call to get up to speed on what the community is focused on.
 
 | Medium                                                                                                                                                                                       | Description                                                    |
 | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------------------------------------------------- |
 | [Announcements Telegram](https://t.me/farcasterxyz)                                                                                                                                          | A channel for major protocol announcements.                    |
-| [Developer Telegram](https://t.me/farcasterdevchat)                                                                                                                                          | A channel for developer Q&A.                                   |
+| [Developer Telegram]                                                                                                                                          | A channel for developer Q&A.                                   |
 | [Dev Call Invitation](https://calendar.google.com/calendar/u/0?cid=NjA5ZWM4Y2IwMmZiMWM2ZDYyMTkzNWM1YWNkZTRlNWExN2YxOWQ2NDU3NTA3MjQwMTk3YmJlZGFjYTQ3MjZlOEBncm91cC5jYWxlbmRhci5nb29nbGUuY29t) | Open Zoom call for developers every other Thursday at 10am PT. |
 | [Dev Call Agenda](https://warpcast.notion.site/b08fed5cbf884e6a80b3acc2dd0666b2?v=4b51e7442af14b48a69871299c22e288)                                                                          | Agendas for upcoming and prior dev calls.                      |
 | [Dev Call Recordings](https://www.youtube.com/watch?v=lmGXWP5m1_Y&list=PL0eq1PLf6eUeZnPtyKMS6uN9I5iRIlnvq)                                                                                   | Recordings of prior dev calls.                                 |


### PR DESCRIPTION
Identified and removed a scam link to Telegram from the official documentation that redirected to a scam site. Additionally, corrected two errors in the text.