### PR TITLE
docs: Fix phrasing in "Getting Started" section Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Farcaster is a protocol for building decentralized social apps. This repository 
 
 If you are instead looking for:
 
-1. How to get started, check out [farcaster.xyz](https://www.farcaster.xyz).
+1. To get started, check out [farcaster.xyz](https://www.farcaster.xyz).
 2. Developer documentation, check out [docs.farcaster.xyz](https://docs.farcaster.xyz).
 
 ## Specifications


### PR DESCRIPTION
In the "Getting Started" section, the current phrasing could be clearer. The original sentence is:

1. How to get started, check out [[farcaster.xyz](https://www.farcaster.xyz/)](https://www.farcaster.xyz).

This can be improved for clarity. The revised version would be:

1. To get started, check out [[farcaster.xyz](https://www.farcaster.xyz/)](https://www.farcaster.xyz).

This change makes the instruction more straightforward and easier to understand.