### PR TITLE
docs: Fix repetition error in validation rule Update SPECIFICATION.md

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -468,7 +468,7 @@ A UsernameProof message `m` must pass these validations:
 
 A UsernameProof message `m` of type `USERNAME_TYPE_FNAME` must also pass these validations:
 
-1. `m.data.body.name` name must match the regular expression `/^[a-z0-9][a-z0-9-]{0,15}$/`.
+1. `m.data.body.name` must match the regular expression `/^[a-z0-9][a-z0-9-]{0,15}$/`.
 2. `m.data.body.owner` must be the custody address of the fid.
 3. `m.data.body.signature` must be a valid ECDSA signature on the EIP-712 Username Proof message from the owner or the public key of the fname server.
 


### PR DESCRIPTION
I noticed a issue in the validation rule where the word "name" was mistakenly repeated in the sentence. Specifically, the line:

**"m.data.body.name name must match the regular expression /^[a-z0-9][a-z0-9-]{0,15}$/."**

The word "name" was used twice, which is unnecessary and could cause confusion. I’ve corrected it to:

**"m.data.body.name must match the regular expression /^[a-z0-9][a-z0-9-]{0,15}$/."**

Thank you for considering my pull request.