### PR TITLE
Fix Grammar and Punctuation in Documentation

### DIFF
--- a/docs/OVERVIEW.md
+++ b/docs/OVERVIEW.md
@@ -123,7 +123,7 @@ graph LR
 
 # 7. Conclusion
 
-An astute reader will note that Farcaster lacks features common in social networks. Timestamps are unreliable, data isn't permanent and there are no mechanisms for private messaging. The eventually consistent nature of the network also means that developers are exposed to more complexity when building applications.
+An astute reader will note that Farcaster lacks features common in social networks. Timestamps are unreliable, data isn't permanent, and there are no mechanisms for private messaging. The eventually consistent nature of the network also means that developers are exposed to more complexity when building applications.
 
 Farcaster makes these tradeoffs to achieve a level of decentralization that puts users and developers in control. It is far easier to add features to a decentralized network than it is to try and decentralize a feature-rich network. The protocol is robust enough to build simple, practical and public social networks that people will use.
 

--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -1100,7 +1100,7 @@ Usernames are also valid subdomains (e.g. [foo.fcast.id](http://foo.fcast.id) ) 
 
 **Managing Fname Ownership**
 
-A POST request to the `/transfers` endpoint can be made register, move or deregister a username. The request body must contain :
+A POST request to the `/transfers` endpoint can be made to register, move or deregister a username. The request body must contain :
 
 ```jsx
 {


### PR DESCRIPTION


Changes:

1. docs/SPECIFICATION.md:
- A POST request to the `/transfers` endpoint can be made register, move or deregister a username.
+ A POST request to the `/transfers` endpoint can be made to register, move or deregister a username.

Reason: Added missing "to" for proper infinitive phrase structure.

2. docs/OVERVIEW.md:
- Timestamps are unreliable, data isn't permanent and there are no mechanisms for private messaging.
+ Timestamps are unreliable, data isn't permanent, and there are no mechanisms for private messaging.

Reason: Added serial comma for clarity in technical writing.

These changes improve documentation readability while maintaining technical accuracy.