### PR TITLE
fix: wrong numbering in Cast CRDT conflict resolution rules

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -525,9 +525,9 @@ The Cast CRDT validates and accepts CastAdd and CastRemove messages. The CRDT al
 
 A conflict occurs if there exists a CastAdd Message and a CastRemove message whose `m.hash` and `m.data.body.target_hash` are identical, or if there are two CastRemove messages whose `m.data.body.target_hash` are identical. Conflicts are resolved with the following rules:
 
-2. If `m.data.type` is distinct, discard the CastAdd message.
-1. If `m.data.type` is identical and `m.data.timestamp` values are distinct, discard the message with the lower timestamp.
-1. If `m.data.timestamp` and `m.data.type` values are identical, discard the message with the lower lexicographical order.
+1. If `m.data.type` is distinct, discard the CastAdd message.
+2. If `m.data.type` is identical and `m.data.timestamp` values are distinct, discard the message with the lower timestamp.
+3. If `m.data.timestamp` and `m.data.type` values are identical, discard the message with the lower lexicographical order.
 
 The Cast CRDT has a per-unit size limit of 5,000.
 


### PR DESCRIPTION
Corrects the inconsistent numbering in section 3.1.3 Cast CRDT conflict resolution rules, changing from "2, 1, 1" to proper sequential numbering "1, 2, 3" for better readability and consistency.