### PR TITLE
Update GitHub Actions versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,10 +15,10 @@ jobs:
     
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: install node
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           cache: "yarn"
           node-version: "18"


### PR DESCRIPTION
  Updated actions/checkout and actions/setup-node to v4, the latest stable versions as of 2025.
  Using v4 ensures better compatibility and support with current Node.js versions.
  References:
  - https://github.com/actions/checkout/releases/tag/v4.0.0
  - https://github.com/actions/setup-node/releases/tag/v4.0.0