### PR TITLE
Updated actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
     
     steps:
       - name: checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: install node
         uses: actions/setup-node@v3


### PR DESCRIPTION
Updated actions/checkout from v3 to v4 across all CI workflows.
This ensures improved compatibility and security by using the latest version of the action.
Confirmation Link:

https://github.com/actions/checkout/releases/tag/v4.2.2