### PR TITLE
Add a method to return a FID by an authorized verification address

### DIFF
--- a/docs/SPECIFICATION.md
+++ b/docs/SPECIFICATION.md
@@ -847,6 +847,7 @@ service HubService {
   // Verifications
   rpc GetVerification(VerificationRequest) returns (Message);
   rpc GetVerificationsByFid(FidRequest) returns (MessagesResponse);
+  rpc GetFidByVerification(VerificationFidRequest) returns (VerificationFidResponse);
 
    // OnChain Events
    rpc GetOnChainSigner(SignerRequest) returns (OnChainEvent);
@@ -1083,6 +1084,14 @@ enum StoreType {
 message StorageLimit {
    StoreType store_type = 1;
    uint64 limit = 2;
+}
+
+message VerificationFidRequest {
+  bytes address = 1;
+}
+
+message VerificationFidResponse {
+  uint64 fid = 1;
 }
 ```
 


### PR DESCRIPTION
Add `GetFidByVerification` to Hub which allows a developer to take an authorized address and return a FID. 

The use case here is we ( Calaxy - https://calaxy.com ) are integrating with both Base.app and Farcaster. When logging in with Base, an ethereum address is returned ( ref: https://docs.base.org/base-account/overview/what-is-base-account ). When logging in with Farcaster, a FID is returned. 

- With an FID, it's possible currently to get a list of authorized ethereum addresses and match a previous "Base.app login" with a new "Farcaster login" to return the same user context

- With just the address, its not currently possible to return an associated FID

This will be especially important as current Base.app applications with "Login with Base.app" end up becoming mini apps and using the embedded Farcaster SDK.

Open to anything with regards to naming. I tried to make it match the feel of what's there.