### PR TITLE
Add Farcaster_RPC_Example.py

### DIFF
--- a/Farcaster_RPC_Example.py,
+++ b/Farcaster_RPC_Example.py,
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+# Example Python script to interact with Farcaster Protocol
+
+import requests
+
+# Example: Fetch latest casts from Farcaster API
+API_URL = "https://api.farcaster.xyz/v1/casts"
+
+def get_latest_casts(limit=5):
+    params = {"limit": limit}
+    response = requests.get(API_URL, params=params)
+    if response.status_code == 200:
+        data = response.json()
+        for cast in data.get("casts", []):
+            print(f"{cast['username']}: {cast['text']}")
+    else:
+        print(f"Error fetching casts: {response.status_code}")
+
+if __name__ == "__main__":
+    print("Latest Farcaster casts:")
+    get_latest_casts()


### PR DESCRIPTION
This PR adds `Farcaster_RPC_Example.py, a simple Python script demonstrating how to interact with the Farcaster Protocol API.

What’s included:

* Fetching latest casts using Farcaster public API
* Displaying username and message text in console
* Lightweight example for new developers to start building on Farcaster

Why it matters:

* Provides a practical starting point for developers exploring Farcaster
* Complements the technical specification with a ready-to-run example
* Lowers the entry barrier for building decentralized social apps on Farcaster

