### PR TITLE
fix: pre-download node-gyp headers to avoid install race condition

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
           key: ${{ runner.os }}--node--${{ hashFiles('**/yarn.lock') }}
 
       - name: Install dependencies
-        run: yarn install
+        run: |
+          npx node-gyp install
+          yarn install
 
       - name: Run prettier check
         run: yarn lint:check

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          npx node-gyp install
+          npx node-gyp@12.2.0 install
           yarn install
 
       - name: Run prettier check


### PR DESCRIPTION
## Summary
- Adds `npx node-gyp install` before `yarn install` in the CI workflow
- This pre-downloads Node.js headers so that multiple native addon compilations during `yarn install` don't race to download the same headers simultaneously

## Files changed
- `.github/workflows/ci.yml` - added `npx node-gyp install` before `yarn install`